### PR TITLE
Add project permission allow-rule for gh issue create

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "permissions": {
+    "allow": [
+      "Bash(gh issue create *)"
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds `.claude/settings.json` with a single project-scoped permission allow-rule:

```json
{ "permissions": { "allow": ["Bash(gh issue create *)"] } }
```

## Why

While planning the parties/cantonal/federal **outreach-email** effort, we filed the work as GitHub issues before implementation. This rule lets `gh issue create` run without a per-command approval prompt, scoped to this project.

## Context / follow-ups

This PR contains **only** the permission rule — no feature code. The planned work is tracked in:

- #32 — generalize `send_campaign_emails` to audience-based campaigns (next to implement)
- #33 — compile local (gitignored) recipient lists for the four audiences
- #34 — review & send the announcement to the four audiences
- #35 — tag party/Fraktion accounts in vote titles (deferred)

## Notes for reviewer

- No code, dependency, or workflow changes; nothing to run or test.
- Committing this makes the allow-rule available to anyone on the branch. Remove it if you'd rather keep permission rules out of version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)