### PR TITLE
Ignore Claude Code local settings and worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ zurichratsinfo
 data/email_overrides.yaml
 
 out/
+
+# Claude Code (local, machine-specific)
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## What

Adds two entries to `.gitignore`:
- `.claude/settings.local.json` — machine-specific allow/deny rules (e.g., temporary permission shortcuts)
- `.claude/worktrees/` — session-specific git worktrees

## Why

Claude Code worktrees and local settings are transient, machine-specific, and should never be committed to a shared repo. This is standard hygiene for repos that use Claude Code.

## Notes

- No code or functionality changes.
- Safe to commit to a public repo — the ignore entries themselves contain no sensitive data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)