### PR TITLE
send_campaign_emails: recipient-list sourcing docs + formal (Sie) address form

### DIFF
--- a/cmd/send_campaign_emails/README.md
+++ b/cmd/send_campaign_emails/README.md
@@ -131,10 +131,23 @@ recipients:
 
 ### Sourcing the recipient lists
 
-Use open data for the *who* (names, party, role), then fill emails manually from official profile/party pages:
+Both parliaments publish members' contact emails through their data services, so
+most entries need no manual filling (verified 2026-07):
 
-- **Federal (ZH):** parlament.ch OData `Councillors` + `Cantons` for the National-/Ständerat members representing Zürich; emails are often `firstname.lastname@parl.ch`.
-- **Cantonal (ZH):** Kantonsrat member roster (`kantonsrat.zh.ch/mitglieder/`, 180) + Regierungsrat (`zh.ch/de/regierungsrat.html`, 7).
-- **Parties:** official contact addresses from each party's website.
+- **Federal (ZH):** roster via parlament.ch OData
+  (`MemberCouncil`, `CantonAbbreviation eq 'ZH' and Active eq true`); each member's
+  *published* email via the legacy REST API
+  `ws-old.parlament.ch/councillors/<id>?format=json` (`contact.emailWork`).
+  Don't guess `firstname.lastname@parl.ch` — several members publish a different
+  address. A few publish none; leave `email` empty so the tool skips them.
+- **Cantonal (ZH):** `kantonsrat.zh.ch/mitglieder/` ships the full roster —
+  including published emails, party, and gender — in the page's Nuxt
+  `_payload.json`. Regierungsrat members (`zh.ch/de/regierungsrat.html`) publish
+  no personal emails; use the Direktionsassistenz/office address from each
+  member's zh.ch page.
+- **Parties:** official contact addresses from each party's website (some hide
+  them behind Cloudflare `data-cfemail` obfuscation or block scraping — check
+  the impressum page, or fill manually). Watch for shared secretariats: the
+  same address can appear in both the city and the cantonal list.
 
 Always review the list via `--preview` before any real send.

--- a/cmd/send_campaign_emails/README.md
+++ b/cmd/send_campaign_emails/README.md
@@ -117,17 +117,36 @@ recipients:
     email: info@spzuerich.ch
     type: org                   # "person" (default) or "org"
     party: SP
-  - name: Erika Musterfrau      # person
+  - name: Erika Musterfrau      # person, du
     email: erika@example.ch
     type: person
-    gender: weiblich            # drives Liebe/Lieber salutation
+    gender: weiblich            # drives Liebe/Lieber (du) or Frau/Herr (Sie)
     role: Kantonsrätin
     party: GLP
+  - name: Max Mustermann        # person, Sie
+    lastname: Mustermann        # surname for the formal salutation
+    email: max@example.ch
+    type: person
+    formal: true                # -> "Sehr geehrter Herr Mustermann" + Sie
+    gender: männlich
+    role: Nationalrat
+    party: FDP
 ```
 
-- `type: org` → greeting "Guten Tag" (uses *ihr*); `type: person` → "Liebe/Lieber <Name>" (uses *du*).
+- Greeting/pronouns: `type: org` → "Guten Tag" + *ihr*; `type: person` with `formal: true` → "Sehr geehrte/r Frau/Herr &lt;lastname&gt;" + *Sie*; otherwise → "Liebe/Lieber &lt;Name&gt;" + *du*.
 - Entries without an `email` are skipped with a warning.
 - `--recipients <file>` overrides the default file for an audience (handy for testing against `recipients.example.yaml`).
+- Run verify (no flag) to eyeball the **Anrede** column (du / Sie / ihr) before sending.
+
+### du or Sie? (formal address)
+
+Cold outreach carries an asymmetric risk: *Sie* to someone who'd have accepted *du* is nearly free, but *du* to someone who expects *Sie* can get the mail dismissed. So the default is *du* (fits the grassroots voice), and *Sie* is switched on only where *du* genuinely misfires. The `formal` flag is seeded per person by this heuristic:
+
+- **High office → Sie:** Regierungsrat and Ständerat (also, those go to office inboxes).
+- **Older cohort → Sie:** born before **1970** (~55+), the point where *du*-culture stops being safe across parties.
+- **Everyone else → du.**
+
+Age comes from the same sources as the roster (`birthdate` in the kantonsrat payload, `birthDate` from the parl.ch API). The flag is written into each entry with a comment noting the reason (`# Sie: geb. 1961` / `# Sie: Ständerat (Amt)`); set `formal:` explicitly on any entry to override. Party orgs stay informal (*ihr*).
 
 ### Sourcing the recipient lists
 

--- a/cmd/send_campaign_emails/main.go
+++ b/cmd/send_campaign_emails/main.go
@@ -79,24 +79,39 @@ var audienceConfigs = map[string]audienceConfig{
 }
 
 // generalBody renders the general intro + heads-up announcement used by all
-// audience campaigns. Pronouns and greeting adapt to org vs. person recipients.
+// audience campaigns. Greeting and pronouns adapt to three address forms:
+//   - org (any):        "Guten Tag" + ihr (informal plural)
+//   - person, formal:   "Sehr geehrte/r Frau/Herr <Name>" + Sie
+//   - person, informal: "Liebe/Lieber <Name>" + du
 func generalBody(r Recipient) string {
-	greeting := "Guten Tag"
-	followShare := "Ich würde mich freuen, wenn ihr dem Account folgt und den einen oder anderen Beitrag teilt. Über Feedback und Ideen freue ich mich jederzeit."
-	if r.Type != "org" {
+	var greeting, followShare string
+	switch {
+	case r.Type == "org":
+		greeting = "Guten Tag"
+		followShare = "Ich würde mich freuen, wenn ihr dem Account folgt. Über Feedback und Ideen freue ich mich jederzeit."
+	case r.Formal:
+		// Formal address uses the surname only ("Sehr geehrte Frau Moser").
+		// Fall back to the full name if no lastname is curated.
+		name := r.Lastname
+		if name == "" {
+			name = r.Name
+		}
+		greeting = fmt.Sprintf("%s %s", formalSalutation(r.Gender), name)
+		followShare = "Ich würde mich freuen, wenn Sie dem Account folgen. Über Feedback und Ideen freue ich mich jederzeit."
+	default:
 		greeting = fmt.Sprintf("%s %s", r.Salutation, r.Name)
-		followShare = "Ich würde mich freuen, wenn du dem Account folgst und den einen oder anderen Beitrag teilst. Über Feedback und Ideen freue ich mich jederzeit."
+		followShare = "Ich würde mich freuen, wenn du dem Account folgst. Über Feedback und Ideen freue ich mich jederzeit."
 	}
 	return fmt.Sprintf(`%s
 
-zuerichratsinfo ist ein zivilgesellschaftliches Projekt, das die Abstimmungsresultate aus dem Gemeinderat der Stadt Zürich auf Social Media veröffentlicht – transparent, automatisiert und für alle nachvollziehbar. Bei jedem Geschäft markieren wir jeweils die beteiligten Politikerinnen und Politiker.
+zuerichratsinfo ist ein zivilgesellschaftliches Projekt, das die Abstimmungsresultate aus dem Gemeinderat der Stadt Zürich auf Social Media veröffentlicht, transparent, automatisiert und für alle nachvollziehbar. Zudem markieren wir jeweils die Politikernnen und Politiker, welche die entsprechenden Vorstösse etc. eingereicht haben.
 
 Zu finden sind wir auf:
 🔵 Bluesky: https://bsky.app/profile/zuerichratsinfo.bsky.social
 ✖️ X: https://x.com/zuerichratsinfo
 📸 Instagram: https://www.instagram.com/zueriratsinfo
 
-Aktuell liegt der Fokus auf der Stadt Zürich. Eine Ausweitung auf Kanton und Bund ist geplant – wir melden uns wieder, sobald es so weit ist.
+Wir arbeiten laufend daran, die Posts weiterzuentwickeln, zum Beispiel kürzlich mit Statistiken, wie die einzelnen Fraktionen abgestimmt haben. Aktuell liegt der Fokus auf der Stadt Zürich. Eine Ausweitung auf Kantonsrat und Bundesparlament ist ein weiterer geplanter Meilenstein.
 
 %s
 
@@ -167,6 +182,8 @@ type Recipient struct {
 	Type        string // "person" (default) or "org"
 	Role        string // e.g. "Nationalrätin" (audience campaigns)
 	Party       string // e.g. "SP" (audience campaigns)
+	Formal      bool   // person only: use Sie ("Sehr geehrte/r …") instead of du
+	Lastname    string // person only: surname for the formal salutation
 }
 
 // Campaign is a fully-resolved email campaign: a subject, the recipient list,
@@ -187,6 +204,11 @@ type audienceRecipient struct {
 	Gender string `yaml:"gender"`
 	Role   string `yaml:"role"`
 	Party  string `yaml:"party"`
+	// Formal: person only. true -> Sie ("Sehr geehrte/r …"), false/unset -> du.
+	// Seeded by the age+office heuristic (see README); hand-tune per entry.
+	Formal *bool `yaml:"formal"`
+	// Lastname: person only, surname for the formal salutation ("… Frau Moser").
+	Lastname string `yaml:"lastname"`
 }
 
 type audienceRecipientsFile struct {
@@ -289,6 +311,7 @@ func loadAudienceRecipients(path string) []Recipient {
 		if typ != "org" {
 			sal = salutation(e.Gender)
 		}
+		formal := e.Formal != nil && *e.Formal
 		recipients = append(recipients, Recipient{
 			Name:       e.Name,
 			Email:      e.Email,
@@ -298,6 +321,8 @@ func loadAudienceRecipients(path string) []Recipient {
 			Type:       typ,
 			Role:       e.Role,
 			Party:      e.Party,
+			Formal:     formal,
+			Lastname:   e.Lastname,
 		})
 	}
 	fmt.Fprintf(os.Stderr, "Loaded %d recipients from %s\n", len(recipients), path)
@@ -402,6 +427,25 @@ func salutation(gender string) string {
 	return "Lieber"
 }
 
+func formalSalutation(gender string) string {
+	if gender == "weiblich" {
+		return "Sehr geehrte Frau"
+	}
+	return "Sehr geehrter Herr"
+}
+
+// addressForm is the pronoun a recipient is addressed with, for the verify table.
+func addressForm(r Recipient) string {
+	switch {
+	case r.Type == "org":
+		return "ihr"
+	case r.Formal:
+		return "Sie"
+	default:
+		return "du"
+	}
+}
+
 func loadOverrides(path string) []Override {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -459,11 +503,11 @@ func normalize(s string) string {
 
 func runVerify(c Campaign) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintf(w, "#\tName\tEmail\tType\tGender\tRole\tParty\tPlatform URL\tSource\n")
-	_, _ = fmt.Fprintf(w, "-\t----\t-----\t----\t------\t----\t-----\t------------\t------\n")
+	_, _ = fmt.Fprintf(w, "#\tName\tEmail\tType\tAnrede\tGender\tRole\tParty\tPlatform URL\tSource\n")
+	_, _ = fmt.Fprintf(w, "-\t----\t-----\t----\t------\t------\t----\t-----\t------------\t------\n")
 	for i, r := range c.Recipients {
-		_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			i+1, r.Name, r.Email, r.Type, r.Gender, r.Role, r.Party, r.PlatformURL, r.Source)
+		_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			i+1, r.Name, r.Email, r.Type, addressForm(r), r.Gender, r.Role, r.Party, r.PlatformURL, r.Source)
 	}
 	if err := w.Flush(); err != nil {
 		log.Fatalf("Failed to flush table: %v", err)

--- a/data/campaign_recipients/recipients.example.yaml
+++ b/data/campaign_recipients/recipients.example.yaml
@@ -6,14 +6,20 @@
 # documents the schema only and carries no real addresses.
 #
 # Fields:
-#   name    required. Person full name, or the organization name for parties.
-#   email   required. Entries without an email are skipped.
-#   type    "person" (default) or "org". Drives the greeting:
-#             person -> "Liebe/Lieber <Name>" (by gender)
-#             org    -> "Guten Tag"
-#   gender  "weiblich" | "männlich" — only used for person salutation.
-#   role    optional, informational (shown in the verify table), e.g. "Nationalrätin".
-#   party   optional, informational, e.g. "SP".
+#   name      required. Person full name, or the organization name for parties.
+#   email     required. Entries without an email are skipped.
+#   type      "person" (default) or "org". Drives the greeting:
+#               person -> "Liebe/Lieber <Name>" (du), or "Sehr geehrte/r …" (Sie)
+#               org    -> "Guten Tag" (ihr)
+#   gender    "weiblich" | "männlich" — used for the person salutation.
+#   role      optional, informational (shown in the verify table), e.g. "Nationalrätin".
+#   party     optional, informational, e.g. "SP".
+#   formal    person only, optional. true -> Sie ("Sehr geehrte/r Frau/Herr <lastname>"),
+#             false/unset -> du. Seeded by the age+office heuristic (see the cmd README);
+#             set it explicitly to override the default for a given person.
+#   lastname  person only, optional. Surname used in the formal (Sie) salutation, so it
+#             reads "Sehr geehrte Frau Moser" rather than the full name. Falls back to
+#             `name` when unset.
 
 recipients:
   - name: SP Stadt Zürich
@@ -21,16 +27,18 @@ recipients:
     type: org
     party: SP
 
-  - name: Erika Musterfrau
+  - name: Erika Musterfrau         # young -> du
     email: erika.musterfrau@example.org
     type: person
     gender: weiblich
     role: Kantonsrätin
     party: GLP
 
-  - name: Max Mustermann
+  - name: Max Mustermann           # senior / high office -> Sie
+    lastname: Mustermann
     email: max.mustermann@example.org
     type: person
+    formal: true
     gender: männlich
     role: Nationalrat
     party: FDP


### PR DESCRIPTION
Follow-up work on the audience outreach campaigns (#33). Two parts; the recipient **data files stay local/gitignored** as intended, so they're not in the diff.

## 1. Documented the verified recipient-list sourcing
`cmd/send_campaign_emails/README.md` — the "Sourcing" section now reflects the workflow that actually worked (differs from the issue's assumption):
- Federal: `ws-old.parlament.ch/councillors/<id>` exposes each member's **published** email; guessing `firstname.lastname@parl.ch` is wrong in several cases.
- Cantonal: `kantonsrat.zh.ch/mitglieder/` ships published emails in its Nuxt `_payload.json`; Regierungsrat via zh.ch office addresses.
- Parties: contact/impressum pages, incl. Cloudflare email obfuscation and shared-secretariat notes.

## 2. Added a formal (Sie) address form
Cold outreach reads better with **Sie** for senior / high-office recipients (du can seem presumptuous), while **du** keeps the grassroots voice for everyone else. The reception risk is asymmetric — mis-using Sie is nearly free, mis-using du can get the mail dismissed — so du stays the default and Sie is switched on only where it misfires.

- `generalBody` renders three forms: org → "Guten Tag" + *ihr*; person + `formal` → "Sehr geehrte/r Frau/Herr &lt;lastname&gt;" + *Sie*; else → "Liebe/Lieber &lt;Name&gt;" + *du*.
- `Recipient` / `audienceRecipient` gain `formal` (bool, person-only) and `lastname` (surname for the Sie salutation, falls back to full name).
- Verify table gains an **Anrede** column (du/Sie/ihr) to eyeball before sending.
- Heuristic that seeds `formal` per person (in the local data files): **born before 1970**, or **Regierungsrat / Ständerat** → Sie; else du. `formal:` can be set explicitly to override. Party orgs stay informal (*ihr*).
- Schema documented in `recipients.example.yaml` + README.

Distribution after seeding: federal 20 du / 17 Sie; cantonal 107 du / 69 Sie; both party lists all *ihr*.

Breakdown of the recipient lists themselves: see the [summary comment on #33](https://github.com/SiiiTschiii/zuerichratsinfo/issues/33#issuecomment-4892910060).

Refs #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)
